### PR TITLE
Package name under debian-based

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,18 +36,22 @@ class etckeeper {
     /(?i-mx:centos|fedora|redhat)/ => 'rpm',
   }
 
+  $gitpackage = $operatingsystem ? {
+    /(?i-mx:ubuntu|debian)/        => 'git-core',
+    /(?i-mx:centos|fedora|redhat)/ => 'git',
+  }
   Package {
     ensure => present,
   }
-  package { 'git': }
+  package { $gitpackage: }
   package { 'etckeeper':
-    require => [ Package['git'],
-                 File['etckeeper.conf'],
-                 ],
+    require => [ Package[$gitpackage], File['etckeeper.conf'], ],
   }
+
   file { '/etc/etckeeper':
     ensure => directory,
   }
+
   file { 'etckeeper.conf':
     ensure  => present,
     path    => '/etc/etckeeper/etckeeper.conf',
@@ -56,10 +60,11 @@ class etckeeper {
     mode    => '0644',
     content => template('etckeeper/etckeeper.conf.erb'),
   }
+
   exec { 'etckeeper-init':
     command => '/usr/bin/etckeeper init',
     cwd     => '/etc',
     creates => '/etc/.git',
-    require => [ Package['git'], Package['etckeeper'], ],
+    require => [ Package[$gitpackage], Package['etckeeper'], ],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,13 @@ class etckeeper {
     /(?i-mx:ubuntu|debian)/        => 'git-core',
     /(?i-mx:centos|fedora|redhat)/ => 'git',
   }
+
+  $etckeeper_binary = $operatingsystem ? {
+    /(?i-mx:ubuntu|debian)/        => '/usr/sbin/etckeeper',
+    /(?i-mx:centos|fedora|redhat)/ => '/usr/bin/etckeeper',
+  }
+
+
   Package {
     ensure => present,
   }
@@ -66,7 +73,7 @@ class etckeeper {
   }
 
   exec { 'etckeeper-init':
-    command => '/usr/bin/etckeeper init',
+    command => "${etckeeper_binary} init",
     cwd     => '/etc',
     creates => '/etc/.git',
     require => [ Package[$gitpackage], Package['etckeeper'], ],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,11 @@ class etckeeper {
   Package {
     ensure => present,
   }
-  package { $gitpackage: }
+
+  if !defined(Package[$gitpackage]) {
+    package { $gitpackage: }
+  }
+
   package { 'etckeeper':
     require => [ Package[$gitpackage], File['etckeeper.conf'], ],
   }


### PR DESCRIPTION
Modified init.pp to manage different package name: under my Ubuntu server the git package does not exists, the right name is 'git-core'
