### PR TITLE
[Bug] Requiring conf file for package breaks Debian install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,12 +50,13 @@ class etckeeper {
   }
 
   package { 'etckeeper':
-    require => [ Package[$gitpackage], File['etckeeper.conf'], ],
+    require => Package[$gitpackage],
   }
 
   file { '/etc/etckeeper':
-    ensure => directory,
-    mode   => 0755,
+    ensure  => directory,
+    mode    => 0755,
+    require => Package['etckeeper'],
   }
 
   file { 'etckeeper.conf':
@@ -65,6 +66,7 @@ class etckeeper {
     group   => root,
     mode    => '0644',
     content => template('etckeeper/etckeeper.conf.erb'),
+    require => [ Package['etckeeper'], File['/etc/etckeeper'] ],
   }
 
   exec { 'etckeeper-init':
@@ -72,6 +74,6 @@ class etckeeper {
     path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     cwd     => '/etc',
     creates => '/etc/.git',
-    require => [ Package[$gitpackage], Package['etckeeper'], ],
+    require => [ Package[$gitpackage], Package['etckeeper'], File['etckeeper.conf'] ],
   }
 }


### PR DESCRIPTION
Module is unusable on Debian since Dpkg complaints about configuration files already exists on the system:

```
err: /Stage[main]/Etckeeper/Package[etckeeper]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install etckeeper' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  etckeeper
0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
Need to get 32.5 kB of archives.
After this operation, 389 kB of additional disk space will be used.
Get:1 http://ftp.es.debian.org/debian/ squeeze/main etckeeper all 0.48 [32.5 kB]
Preconfiguring packages ...
Fetched 32.5 kB in 0s (102 kB/s)
Selecting previously deselected package etckeeper.
(Reading database ... 41022 files and directories currently installed.)
Unpacking etckeeper (from .../etckeeper_0.48_all.deb) ...
Processing triggers for man-db ...
Setting up etckeeper (0.48) ...

Configuration file `/etc/etckeeper/etckeeper.conf'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
 ==> Using current old file as you requested.
: not foundper/etckeeper.conf: 6:
dpkg: error processing etckeeper (--configure):
 subprocess installed post-installation script returned error exit status 127
configured to not write apport reports
Processing triggers for python-central ...
Errors were encountered while processing:
 etckeeper
E: Sub-process /usr/bin/dpkg returned an error code (1)

notice: /Stage[main]/Etckeeper/Exec[etckeeper-init]: Dependency Package[etckeeper] has failures: true
warning: /Stage[main]/Etckeeper/Exec[etckeeper-init]: Skipping because of failed dependencies~
```
