### PR TITLE
ensure root's user.name and user.email are configured

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -3,3 +3,6 @@ version      '0.0.8'
 author       'Thomas Van Doren'
 license      'BSD'
 project_page 'https://github.com/thomasvandoren/puppet-etckeeper'
+
+# for $root_dir fact
+dependency 'puppetlabs/stdlib', '>= 2.2.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,11 +67,31 @@ class etckeeper {
     content => template('etckeeper/etckeeper.conf.erb'),
   }
 
+  exec { "etckeeper-gitconfig-root@${hostname}-name":
+    path        => '/bin:/usr/bin',
+    environment => [ "HOME=${root_home}" ],
+    unless      => 'git config user.name',
+    command     => 'git config --global user.name root',
+    require     => Package[$gitpackage],
+  }
+  exec { "etckeeper-gitconfig-root@${hostname}-email":
+    path        => '/bin:/usr/bin',
+    environment => [ "HOME=${root_home}" ],
+    unless      => 'git config user.email',
+    command     => "git config --global user.email root@${hostname}",
+    require     => Package[$gitpackage],
+  }
+
   exec { 'etckeeper-init':
     command => 'etckeeper init',
     path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     cwd     => '/etc',
     creates => '/etc/.git',
-    require => [ Package[$gitpackage], Package['etckeeper'], ],
+    require => [
+       Package[$gitpackage],
+       Package['etckeeper'],
+       Exec["etckeeper-gitconfig-root@${hostname}-email"],
+       Exec["etckeeper-gitconfig-root@${hostname}-name"],
+    ],
   }
 }


### PR DESCRIPTION
On occasion, I've noticed some weirdness when root does not have a git user
and email address defined.  This adds configuration to ensure that
~root/.gitconfig has a basic user and email defined, e.g.

```
user.name   root
user.email  root@${hostname}
```

Note that this depends on puppetlabs-stdlib's custom fact of $root_dir
being available...  As the stdlib module is a pretty common requirement,
I'm not terribly worried about it here, but we could find an alternate way
if essential.

Another approach would be to create, say, a
/etc/etckeeper/init.d/41-git-name, and have that set the config from inside
a new repository.  This would solve the problem going forward, but not so
much for any current systems.
