### PR TITLE
added etckeeper commit; need to adjust return code

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,5 +73,12 @@ class etckeeper {
     cwd     => '/etc',
     creates => '/etc/.git',
     require => [ Package[$gitpackage], Package['etckeeper'], ],
+    notify  => [ Exec['etckeeper-initial-commit'], ],
+  }
+
+  exec { 'etckeeper-initial-commit':
+    command => 'etckeeper commit "initial commit with package install and configuration"',
+    path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    cwd     => '/etc',
   }
 }


### PR DESCRIPTION
Thomas,

Etckeeper does not run a commit on init; it takes an additional step.  I think this is needed functionality and have added this.

Yes, this does eventually happen when cron runs.  However, in waiting any changes made between etckeeper installation and that first commit are lost.  Why run etckeeper unless you're trying to capture changes?

I'll note, while the implementation seems straightforward, running --debug catches an error (thus the commit message):
Error: /Stage[main]/Etckeeper/Exec[etckeeper-initial-commit]: Failed to call refresh: etckeeper commit "initial commit with package install and configuration" returned 1 instead of one of [0]
Error: /Stage[main]/Etckeeper/Exec[etckeeper-initial-commit]: etckeeper commit "initial commit with package install and configuration" returned 1 instead of one of [0]

I can't really figure out where the complaint is coming from.  As I'm using only etckeeper commands, it seems the fix needs to happen there.  I browsed /etc/etckeeper/commit.d and nothing jumps out.  Running the init and commit manually, everything seems fine.

All this is to say that I believe the puppet code is clean; but can understand wanting to deal with the 'error'.  I'd appreciate some help in that.

I look forward to hearing your thoughts.

Thanks,

-- Jess
