### PR TITLE
Add missing @s.

### DIFF
--- a/templates/etckeeper.conf.erb
+++ b/templates/etckeeper.conf.erb
@@ -31,8 +31,8 @@ DARCS_COMMIT_OPTIONS="-a"
 
 # The high-level package manager that's being used.
 # (apt, pacman-g2, yum etc)
-HIGHLEVEL_PACKAGE_MANAGER=<%= etckeeper_high_pkg_mgr %>
+HIGHLEVEL_PACKAGE_MANAGER=<%= @etckeeper_high_pkg_mgr %>
 
 # The low-level package manager that's being used.
 # (dpkg, rpm, pacman-g2, etc)
-LOWLEVEL_PACKAGE_MANAGER=<%= etckeeper_low_pkg_mgr %>
+LOWLEVEL_PACKAGE_MANAGER=<%= @etckeeper_low_pkg_mgr %>


### PR DESCRIPTION
This avoids using variable access that has been deprecated in puppet v3
