### PR TITLE
Depend on puppetlabs-git to manage git package

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
   symlinks:
     "etckeeper": "#{source_dir}"
+  forge_modules:
+    git: "puppetlabs/git"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,9 @@ class etckeeper (
   $etckeeper_author = false,
   $etckeeper_email = false
   ) {
+
+  require ::git
+
   # HIGHLEVEL_PACKAGE_MANAGER config setting.
   $etckeeper_high_pkg_mgr = $::operatingsystem ? {
     /(?i-mx:ubuntu|debian)/                           => 'apt',
@@ -56,21 +59,12 @@ class etckeeper (
     /(?i-mx:centos|fedora|redhat|oraclelinux|amazon)/ => 'rpm',
   }
 
-  $gitpackage = $::operatingsystem ? {
-    /(?i-mx:ubuntu|debian)/                           => 'git-core',
-    /(?i-mx:centos|fedora|redhat|oraclelinux|amazon)/ => 'git',
-  }
-
   Package {
     ensure => present,
   }
 
-  if !defined(Package[$gitpackage]) {
-    package { $gitpackage: }
-  }
-
   package { 'etckeeper':
-    require => [ Package[$gitpackage], File['etckeeper.conf'], ],
+    require => File['etckeeper.conf'],
   }
 
   file { '/etc/etckeeper':
@@ -92,6 +86,6 @@ class etckeeper (
     path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     cwd     => '/etc',
     creates => '/etc/.git',
-    require => [ Package[$gitpackage], Package['etckeeper'], ],
+    require => Package['etckeeper'],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,10 @@
   "project_page": "https://github.com/thomasvandoren/puppet-etckeeper",
   "issues_url": "https://github.com/thomasvandoren/puppet-etckeeper/issues",
   "description": "Install and configure etckeeper using git.",
-  "dependencies": []
+  "dependencies": [
+    {
+      "name": "puppetlabs-git",
+      "version_range": ">= 0.0.2"
+    },
+  ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,6 @@
     {
       "name": "puppetlabs/git",
       "version_range": ">= 0.0.2"
-    },
+    }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "description": "Install and configure etckeeper using git.",
   "dependencies": [
     {
-      "name": "puppetlabs-git",
+      "name": "puppetlabs/git",
       "version_range": ">= 0.0.2"
     },
   ]

--- a/spec/classes/etckeeper_spec.rb
+++ b/spec/classes/etckeeper_spec.rb
@@ -10,7 +10,8 @@ describe 'etckeeper', :type => 'class' do
     end # let
 
     it do
-      should contain_package('git-core').with_ensure('present')
+      should contain_class('git')
+
       should contain_package('etckeeper').with_ensure('present')
 
       should contain_file('/etc/etckeeper').with(:ensure => 'directory',
@@ -41,7 +42,8 @@ describe 'etckeeper', :type => 'class' do
     end # let
 
     it do
-      should contain_package('git').with_ensure('present')
+      should contain_class('git')
+
       should contain_package('etckeeper').with_ensure('present')
 
       should contain_file('/etc/etckeeper').with(:ensure => 'directory',
@@ -70,7 +72,7 @@ describe 'etckeeper', :type => 'class' do
     end # let
 
     it do
-      should contain_package('git-core').with_ensure('present')
+      should contain_class('git')
       should contain_file('etckeeper.conf').with_content(/^HIGHLEVEL_PACKAGE_MANAGER=apt$/)
       should contain_file('etckeeper.conf').with_content(/^LOWLEVEL_PACKAGE_MANAGER=dpkg$/)
     end # it
@@ -84,7 +86,7 @@ describe 'etckeeper', :type => 'class' do
     end # let
 
     it do
-      should contain_package('git').with_ensure('present')
+      should contain_class('git')
       should contain_file('etckeeper.conf').with_content(/^HIGHLEVEL_PACKAGE_MANAGER=yum$/)
       should contain_file('etckeeper.conf').with_content(/^LOWLEVEL_PACKAGE_MANAGER=rpm$/)
     end # it


### PR DESCRIPTION
This is a suggestion to switch to https://github.com/puppetlabs/puppetlabs-git.

I'm using some modules that rely on puppetlabs-git. It produces a conflict with etckeeper, depending on the inclusion order.

Although etckeeper does it fine with the `defined()` check, I think that leveraging puppetlabs-git is better from a _single responsibility principle_ perspective.
