### PR TITLE
Implemented PUSH_REMOTE option for etckeeper

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,7 @@ class etckeeper (
         group   => 'root',
         mode    => '0755',
         content => template('etckeeper/99push')
+      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,14 @@
 #   Email to use when committing (user.email).
 #   Default: false (do not set)
 #
+# [*etckeeper_repo*]
+#   URL of the repo to push commits to
+#   Default: undef (do not push commits)
+#
+# [*etckeeper_remote*]
+#   Name of the remote. Has no effect unless etckeeper_repo is set
+#   Default: origin
+#
 # === Variables
 #
 # [*etckeeper_high_pkg_mgr*]
@@ -42,7 +50,9 @@
 #
 class etckeeper (
   $etckeeper_author = false,
-  $etckeeper_email = false
+  $etckeeper_email  = false,
+  $etckeeper_repo   = false,
+  $etckeeper_remote = 'origin'
   ) {
   # HIGHLEVEL_PACKAGE_MANAGER config setting.
   $etckeeper_high_pkg_mgr = $::operatingsystem ? {
@@ -93,5 +103,15 @@ class etckeeper (
     cwd     => '/etc',
     creates => '/etc/.git',
     require => [ Package[$gitpackage], Package['etckeeper'], ],
+  }
+
+  if ( $etckeeper_repo ) {
+    exec { 'etckeeper-remoteadd':
+      command => "git remote add ${etckeeper_remote} ${etckeeper_repo}",
+      path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      cwd     => '/etc',
+      unless  => "git remote | grep ${etckeeper_remote}",
+      require => Exec['etckeeper-init'],
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,5 +113,16 @@ class etckeeper (
       unless  => "git remote | grep ${etckeeper_remote}",
       require => Exec['etckeeper-init'],
     }
+
+    if ($::operatingsystem == 'debian') {
+      #The etckeeper in Debian doesn't support automatic pushing, so need to do it with cron
+      cron { 'etckeeper-push':
+        ensure      => present,
+        command     => "git push ${etckeeper_remote}",
+        environment => 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        user        => 'root',
+        hour        => '*'
+      }
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,10 +118,11 @@ class etckeeper (
       #The etckeeper in Debian doesn't support automatic pushing, so need to do it with cron
       cron { 'etckeeper-push':
         ensure      => present,
-        command     => "git push ${etckeeper_remote}",
+        command     => "git push ${etckeeper_remote} -C /etc",
         environment => 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         user        => 'root',
-        hour        => '*'
+        hour        => '*',
+        minute      => '0'
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,15 +115,13 @@ class etckeeper (
     }
 
     if ($::operatingsystem == 'debian') {
-      #The etckeeper in Debian doesn't support automatic pushing, so need to do it with cron
-      cron { 'etckeeper-push':
-        ensure      => present,
-        command     => "git push ${etckeeper_remote} -C /etc",
-        environment => 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        user        => 'root',
-        hour        => '*',
-        minute      => '0'
-      }
+      #The etckeeper in Debian doesn't support automatic pushing, so need to monkeypatch
+      file { '/etc/etckeeper/commit.d/99push':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template('etckeeper/99push')
     }
   }
 }

--- a/templates/99push
+++ b/templates/99push
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ -n "$PUSH_REMOTE" ]; then
+	if [ "$VCS" = git ] && [ -d .git ]; then
+		git push "$PUSH_REMOTE" master || true
+	else
+		echo "PUSH_REMOTE not yet supported for $VCS" >&2
+	fi
+fi

--- a/templates/99push
+++ b/templates/99push
@@ -1,8 +1,6 @@
 #!/bin/sh
-if [ -n "$PUSH_REMOTE" ]; then
-	if [ "$VCS" = git ] && [ -d .git ]; then
-		git push "$PUSH_REMOTE" master || true
-	else
-		echo "PUSH_REMOTE not yet supported for $VCS" >&2
-	fi
+if [ "$VCS" = git ] && [ -d .git ]; then
+   git push <%= @etckeeper_remote %> master || true
+else
+   echo "PUSH_REMOTE not yet supported for $VCS" >&2
 fi

--- a/templates/etckeeper.conf.erb
+++ b/templates/etckeeper.conf.erb
@@ -40,3 +40,11 @@ HIGHLEVEL_PACKAGE_MANAGER=<%= @etckeeper_high_pkg_mgr %>
 # The low-level package manager that's being used.
 # (dpkg, rpm, pacman-g2, etc)
 LOWLEVEL_PACKAGE_MANAGER=<%= @etckeeper_low_pkg_mgr %>
+
+# To push each commit to a remote, put the name of the remote here.
+# (eg, "origin" for git).
+<% if @etckeeper_repo %>
+PUSH_REMOTE="<%= @etckeeper_remote %>"
+<% else %>
+PUSH_REMOTE=""
+<% end %>


### PR DESCRIPTION
This closes issue #14, and adds support for the PUSH_REMOTE option in recent versions of etckeeper. It allows the contents of the etckeeper repo to be pushed to a remote repository automatically (eg, as an off-server backup).

It currently is specific to git (as is the rest of the module)
