### PR TITLE
add PUSH_REMOTE option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,10 @@
 #   Email to use when committing (user.email).
 #   Default: false (do not set)
 #
+# [*push_remote_name*]
+#   Automatic push to a remote branch after commit.
+#   Default: undef (do not push)
+#
 # === Variables
 #
 # [*etckeeper_high_pkg_mgr*]
@@ -42,7 +46,8 @@
 #
 class etckeeper (
   $etckeeper_author = false,
-  $etckeeper_email = false
+  $etckeeper_email = false,
+  $push_remote_name = false, 
   ) {
   # HIGHLEVEL_PACKAGE_MANAGER config setting.
   $etckeeper_high_pkg_mgr = $::operatingsystem ? {

--- a/templates/etckeeper.conf.erb
+++ b/templates/etckeeper.conf.erb
@@ -40,3 +40,11 @@ HIGHLEVEL_PACKAGE_MANAGER=<%= @etckeeper_high_pkg_mgr %>
 # The low-level package manager that's being used.
 # (dpkg, rpm, pacman-g2, etc)
 LOWLEVEL_PACKAGE_MANAGER=<%= @etckeeper_low_pkg_mgr %>
+
+# To push each commit to a remote, put the name of the remote here.
+# # (eg, "origin" for git).
+<% if $push_remote_name %>
+PUSH_REMOTE="<%= $push_remote_name %>"
+<% else %>
+#PUSH_REMOTE="origin"
+<% end %>


### PR DESCRIPTION
Newer versions of etckeeper have PUSH_REMOTE option added. It enables us to automatically push to remote after commit.
